### PR TITLE
Upgrade React 19 and refresh build deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,8 +26,8 @@
         "gatsby-transformer-sharp": "^5.16.0",
         "prism-themes": "^1.9.0",
         "prismjs": "^1.30.0",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1",
+        "react": "^19.2.5",
+        "react-dom": "^19.2.5",
         "sass": "^1.99.0",
         "sharp": "^0.34.5"
       },
@@ -2179,20 +2179,6 @@
       "engines": {
         "node": ">=18.0.0 <26",
         "parcel": "2.x"
-      }
-    },
-    "node_modules/@gatsbyjs/reach-router": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@gatsbyjs/reach-router/-/reach-router-2.0.1.tgz",
-      "integrity": "sha512-gmSZniS9/phwgEgpFARMpNg21PkYDZEpfgEzvkgpE/iku4uvXqCrxr86fXbTpI9mkrhKS1SCTYmLGe60VdHcdQ==",
-      "license": "MIT",
-      "dependencies": {
-        "invariant": "^2.2.4",
-        "prop-types": "^15.8.1"
-      },
-      "peerDependencies": {
-        "react": "18.x",
-        "react-dom": "18.x"
       }
     },
     "node_modules/@gatsbyjs/webpack-hot-middleware": {
@@ -7152,15 +7138,10 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ],
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -7172,6 +7153,9 @@
       },
       "engines": {
         "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
@@ -10813,25 +10797,6 @@
         "url": "https://opencollective.com/core-js"
       }
     },
-    "node_modules/gatsby-link": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/gatsby-link/-/gatsby-link-5.16.0.tgz",
-      "integrity": "sha512-1drjKlnH9Si54npVsAnT46uW7fM7xT1ISgxzMZenhoSfAZYE0ZVqu9BbOJnj784YYLVo9t7YLzQrzP8VMHBFqQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/reach__router": "^1.3.10",
-        "gatsby-page-utils": "^3.16.0",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=18.0.0 <26"
-      },
-      "peerDependencies": {
-        "@gatsbyjs/reach-router": "^2.0.0",
-        "react": "^18.0.0 || ^19.0.0 || ^0.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0 || ^0.0.0"
-      }
-    },
     "node_modules/gatsby-page-utils": {
       "version": "3.16.0",
       "resolved": "https://registry.npmjs.org/gatsby-page-utils/-/gatsby-page-utils-3.16.0.tgz",
@@ -10849,30 +10814,6 @@
       },
       "engines": {
         "node": ">=18.0.0 <26"
-      }
-    },
-    "node_modules/gatsby-page-utils/node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "license": "MIT",
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
       }
     },
     "node_modules/gatsby-parcel-config": {
@@ -11046,30 +10987,6 @@
         "gatsby": "^5.0.0-next"
       }
     },
-    "node_modules/gatsby-plugin-page-creator/node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "license": "MIT",
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
     "node_modules/gatsby-plugin-sass": {
       "version": "6.16.0",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-sass/-/gatsby-plugin-sass-6.16.0.tgz",
@@ -11219,24 +11136,6 @@
         "graphql": "^16.0.0"
       }
     },
-    "node_modules/gatsby-react-router-scroll": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/gatsby-react-router-scroll/-/gatsby-react-router-scroll-6.16.0.tgz",
-      "integrity": "sha512-VtbO98hc73gUyri1wRSQWGT/ENkrvVrlryKA3Xic2rFxcmup4gz2ZWR0zQ8EWJb3Nw/k9toGPd5FnXG3Fp7DuA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=18.0.0 <26"
-      },
-      "peerDependencies": {
-        "@gatsbyjs/reach-router": "^2.0.0",
-        "react": "^18.0.0 || ^19.0.0 || ^0.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0 || ^0.0.0"
-      }
-    },
     "node_modules/gatsby-remark-copy-linked-files": {
       "version": "6.16.0",
       "resolved": "https://registry.npmjs.org/gatsby-remark-copy-linked-files/-/gatsby-remark-copy-linked-files-6.16.0.tgz",
@@ -11368,20 +11267,6 @@
         "gatsby": "^5.0.0-next"
       }
     },
-    "node_modules/gatsby-script": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/gatsby-script/-/gatsby-script-2.16.0.tgz",
-      "integrity": "sha512-NvHn87O+/pFszK75FSR5Na00V36+ZrZH4CTaWa8iosqH/oIyH5RXrpEajGkz4tg5SG/oH/KFNcsCFWOSo8rGlg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0.0 <26"
-      },
-      "peerDependencies": {
-        "@gatsbyjs/reach-router": "^2.0.0",
-        "react": "^18.0.0 || ^19.0.0 || ^0.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0 || ^0.0.0"
-      }
-    },
     "node_modules/gatsby-sharp": {
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/gatsby-sharp/-/gatsby-sharp-1.16.0.tgz",
@@ -11453,30 +11338,6 @@
       },
       "peerDependencies": {
         "gatsby": "^5.0.0-next"
-      }
-    },
-    "node_modules/gatsby-source-filesystem/node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "license": "MIT",
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
       }
     },
     "node_modules/gatsby-transformer-remark": {
@@ -11606,6 +11467,20 @@
       },
       "engines": {
         "node": ">=18.0.0 <26"
+      }
+    },
+    "node_modules/gatsby/node_modules/@gatsbyjs/reach-router": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@gatsbyjs/reach-router/-/reach-router-2.0.1.tgz",
+      "integrity": "sha512-gmSZniS9/phwgEgpFARMpNg21PkYDZEpfgEzvkgpE/iku4uvXqCrxr86fXbTpI9mkrhKS1SCTYmLGe60VdHcdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": "18.x",
+        "react-dom": "18.x"
       }
     },
     "node_modules/gatsby/node_modules/@typescript-eslint/eslint-plugin": {
@@ -11826,30 +11701,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/gatsby/node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "license": "MIT",
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
     "node_modules/gatsby/node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -11877,6 +11728,57 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/gatsby/node_modules/gatsby-link": {
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/gatsby-link/-/gatsby-link-5.16.0.tgz",
+      "integrity": "sha512-1drjKlnH9Si54npVsAnT46uW7fM7xT1ISgxzMZenhoSfAZYE0ZVqu9BbOJnj784YYLVo9t7YLzQrzP8VMHBFqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/reach__router": "^1.3.10",
+        "gatsby-page-utils": "^3.16.0",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=18.0.0 <26"
+      },
+      "peerDependencies": {
+        "@gatsbyjs/reach-router": "^2.0.0",
+        "react": "^18.0.0 || ^19.0.0 || ^0.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^0.0.0"
+      }
+    },
+    "node_modules/gatsby/node_modules/gatsby-react-router-scroll": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/gatsby-react-router-scroll/-/gatsby-react-router-scroll-6.16.0.tgz",
+      "integrity": "sha512-VtbO98hc73gUyri1wRSQWGT/ENkrvVrlryKA3Xic2rFxcmup4gz2ZWR0zQ8EWJb3Nw/k9toGPd5FnXG3Fp7DuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=18.0.0 <26"
+      },
+      "peerDependencies": {
+        "@gatsbyjs/reach-router": "^2.0.0",
+        "react": "^18.0.0 || ^19.0.0 || ^0.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^0.0.0"
+      }
+    },
+    "node_modules/gatsby/node_modules/gatsby-script": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/gatsby-script/-/gatsby-script-2.16.0.tgz",
+      "integrity": "sha512-NvHn87O+/pFszK75FSR5Na00V36+ZrZH4CTaWa8iosqH/oIyH5RXrpEajGkz4tg5SG/oH/KFNcsCFWOSo8rGlg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0 <26"
+      },
+      "peerDependencies": {
+        "@gatsbyjs/reach-router": "^2.0.0",
+        "react": "^18.0.0 || ^19.0.0 || ^0.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^0.0.0"
       }
     },
     "node_modules/gatsby/node_modules/ms": {
@@ -16817,13 +16719,10 @@
       }
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16989,16 +16888,15 @@
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "^19.2.5"
       }
     },
     "node_modules/react-is": {
@@ -18090,13 +17988,10 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/schema-utils": {
       "version": "3.1.1",
@@ -22641,15 +22536,6 @@
         "gatsby-core-utils": "^4.16.0"
       }
     },
-    "@gatsbyjs/reach-router": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@gatsbyjs/reach-router/-/reach-router-2.0.1.tgz",
-      "integrity": "sha512-gmSZniS9/phwgEgpFARMpNg21PkYDZEpfgEzvkgpE/iku4uvXqCrxr86fXbTpI9mkrhKS1SCTYmLGe60VdHcdQ==",
-      "requires": {
-        "invariant": "^2.2.4",
-        "prop-types": "^15.8.1"
-      }
-    },
     "@gatsbyjs/webpack-hot-middleware": {
       "version": "2.25.3",
       "resolved": "https://registry.npmjs.org/@gatsbyjs/webpack-hot-middleware/-/webpack-hot-middleware-2.25.3.tgz",
@@ -25815,9 +25701,9 @@
       }
     },
     "chokidar": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
       "requires": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -28283,6 +28169,15 @@
         "yaml-loader": "^0.8.0"
       },
       "dependencies": {
+        "@gatsbyjs/reach-router": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@gatsbyjs/reach-router/-/reach-router-2.0.1.tgz",
+          "integrity": "sha512-gmSZniS9/phwgEgpFARMpNg21PkYDZEpfgEzvkgpE/iku4uvXqCrxr86fXbTpI9mkrhKS1SCTYmLGe60VdHcdQ==",
+          "requires": {
+            "invariant": "^2.2.4",
+            "prop-types": "^15.8.1"
+          }
+        },
         "@typescript-eslint/eslint-plugin": {
           "version": "5.62.0",
           "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
@@ -28391,21 +28286,6 @@
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
           "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ=="
         },
-        "chokidar": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-          "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-          "requires": {
-            "anymatch": "~3.1.2",
-            "braces": "~3.0.2",
-            "fsevents": "~2.3.2",
-            "glob-parent": "~5.1.2",
-            "is-binary-path": "~2.1.0",
-            "is-glob": "~4.0.1",
-            "normalize-path": "~3.0.0",
-            "readdirp": "~3.6.0"
-          }
-        },
         "debug": {
           "version": "4.4.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -28418,6 +28298,31 @@
           "version": "3.4.3",
           "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
           "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="
+        },
+        "gatsby-link": {
+          "version": "5.16.0",
+          "resolved": "https://registry.npmjs.org/gatsby-link/-/gatsby-link-5.16.0.tgz",
+          "integrity": "sha512-1drjKlnH9Si54npVsAnT46uW7fM7xT1ISgxzMZenhoSfAZYE0ZVqu9BbOJnj784YYLVo9t7YLzQrzP8VMHBFqQ==",
+          "requires": {
+            "@types/reach__router": "^1.3.10",
+            "gatsby-page-utils": "^3.16.0",
+            "prop-types": "^15.8.1"
+          }
+        },
+        "gatsby-react-router-scroll": {
+          "version": "6.16.0",
+          "resolved": "https://registry.npmjs.org/gatsby-react-router-scroll/-/gatsby-react-router-scroll-6.16.0.tgz",
+          "integrity": "sha512-VtbO98hc73gUyri1wRSQWGT/ENkrvVrlryKA3Xic2rFxcmup4gz2ZWR0zQ8EWJb3Nw/k9toGPd5FnXG3Fp7DuA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "prop-types": "^15.8.1"
+          }
+        },
+        "gatsby-script": {
+          "version": "2.16.0",
+          "resolved": "https://registry.npmjs.org/gatsby-script/-/gatsby-script-2.16.0.tgz",
+          "integrity": "sha512-NvHn87O+/pFszK75FSR5Na00V36+ZrZH4CTaWa8iosqH/oIyH5RXrpEajGkz4tg5SG/oH/KFNcsCFWOSo8rGlg==",
+          "requires": {}
         },
         "ms": {
           "version": "2.1.3",
@@ -28538,16 +28443,6 @@
         }
       }
     },
-    "gatsby-link": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/gatsby-link/-/gatsby-link-5.16.0.tgz",
-      "integrity": "sha512-1drjKlnH9Si54npVsAnT46uW7fM7xT1ISgxzMZenhoSfAZYE0ZVqu9BbOJnj784YYLVo9t7YLzQrzP8VMHBFqQ==",
-      "requires": {
-        "@types/reach__router": "^1.3.10",
-        "gatsby-page-utils": "^3.16.0",
-        "prop-types": "^15.8.1"
-      }
-    },
     "gatsby-page-utils": {
       "version": "3.16.0",
       "resolved": "https://registry.npmjs.org/gatsby-page-utils/-/gatsby-page-utils-3.16.0.tgz",
@@ -28561,23 +28456,6 @@
         "glob": "^7.2.3",
         "lodash": "^4.17.21",
         "micromatch": "^4.0.5"
-      },
-      "dependencies": {
-        "chokidar": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-          "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-          "requires": {
-            "anymatch": "~3.1.2",
-            "braces": "~3.0.2",
-            "fsevents": "~2.3.2",
-            "glob-parent": "~5.1.2",
-            "is-binary-path": "~2.1.0",
-            "is-glob": "~4.0.1",
-            "normalize-path": "~3.0.0",
-            "readdirp": "~3.6.0"
-          }
-        }
       }
     },
     "gatsby-parcel-config": {
@@ -28690,23 +28568,6 @@
         "gatsby-plugin-utils": "^4.16.0",
         "globby": "^11.1.0",
         "lodash": "^4.17.21"
-      },
-      "dependencies": {
-        "chokidar": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-          "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-          "requires": {
-            "anymatch": "~3.1.2",
-            "braces": "~3.0.2",
-            "fsevents": "~2.3.2",
-            "glob-parent": "~5.1.2",
-            "is-binary-path": "~2.1.0",
-            "is-glob": "~4.0.1",
-            "normalize-path": "~3.0.0",
-            "readdirp": "~3.6.0"
-          }
-        }
       }
     },
     "gatsby-plugin-sass": {
@@ -28808,15 +28669,6 @@
         "mime": "^3.0.0"
       }
     },
-    "gatsby-react-router-scroll": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/gatsby-react-router-scroll/-/gatsby-react-router-scroll-6.16.0.tgz",
-      "integrity": "sha512-VtbO98hc73gUyri1wRSQWGT/ENkrvVrlryKA3Xic2rFxcmup4gz2ZWR0zQ8EWJb3Nw/k9toGPd5FnXG3Fp7DuA==",
-      "requires": {
-        "@babel/runtime": "^7.20.13",
-        "prop-types": "^15.8.1"
-      }
-    },
     "gatsby-remark-copy-linked-files": {
       "version": "6.16.0",
       "resolved": "https://registry.npmjs.org/gatsby-remark-copy-linked-files/-/gatsby-remark-copy-linked-files-6.16.0.tgz",
@@ -28911,12 +28763,6 @@
         "unist-util-visit": "^2.0.3"
       }
     },
-    "gatsby-script": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/gatsby-script/-/gatsby-script-2.16.0.tgz",
-      "integrity": "sha512-NvHn87O+/pFszK75FSR5Na00V36+ZrZH4CTaWa8iosqH/oIyH5RXrpEajGkz4tg5SG/oH/KFNcsCFWOSo8rGlg==",
-      "requires": {}
-    },
     "gatsby-sharp": {
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/gatsby-sharp/-/gatsby-sharp-1.16.0.tgz",
@@ -28966,23 +28812,6 @@
         "pretty-bytes": "^5.6.0",
         "valid-url": "^1.0.9",
         "xstate": "^4.38.0"
-      },
-      "dependencies": {
-        "chokidar": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-          "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-          "requires": {
-            "anymatch": "~3.1.2",
-            "braces": "~3.0.2",
-            "fsevents": "~2.3.2",
-            "glob-parent": "~5.1.2",
-            "is-binary-path": "~2.1.0",
-            "is-glob": "~4.0.1",
-            "normalize-path": "~3.0.0",
-            "readdirp": "~3.6.0"
-          }
-        }
       }
     },
     "gatsby-transformer-remark": {
@@ -32323,12 +32152,9 @@
       }
     },
     "react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "requires": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="
     },
     "react-dev-utils": {
       "version": "12.0.1",
@@ -32444,12 +32270,11 @@
       }
     },
     "react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "requires": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.27.0"
       }
     },
     "react-is": {
@@ -33192,12 +33017,9 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "requires": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="
     },
     "schema-utils": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
     "gatsby-transformer-sharp": "^5.16.0",
     "prism-themes": "^1.9.0",
     "prismjs": "^1.30.0",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
     "sass": "^1.99.0",
     "sharp": "^0.34.5"
   },

--- a/src/templates/style.scss
+++ b/src/templates/style.scss
@@ -1,3 +1,5 @@
+@use 'sass:map';
+
 $breakpoints: (
   'sm': 'screen and (max-width: 768px)',
   'pc': 'screen and (min-width: 769px)',
@@ -9,7 +11,7 @@ $font-pop: 'ヒラギノ丸ゴ Pro W4', 'ヒラギノ丸ゴ Pro', 'Hiragino Maru
   'Hiragino Kaku Gothic Pro', 'HG丸ｺﾞｼｯｸM-PRO', 'HGMaruGothicMPRO';
 
 @mixin mq($breakpoint: sm) {
-  @media #{map-get($breakpoints, $breakpoint)} {
+  @media #{map.get($breakpoints, $breakpoint)} {
     @content;
   }
 }


### PR DESCRIPTION
## Summary
- upgrade `react` and `react-dom` to `19.2.5`
- refresh locked build dependencies including `sharp` and keep `prettier` on the current v3 line
- migrate the site SCSS from deprecated `map-get` to `sass:map` `map.get`

## Validation
- `npm run lint`
- `npm run build`

## Notes
- build still shows dependency-originated warnings for `punycode` deprecation and the Sass legacy JS API used by `gatsby-plugin-sass`
