### PR TITLE
[codex] Improve accessibility semantics

### DIFF
--- a/src/components/allCategoris.jsx
+++ b/src/components/allCategoris.jsx
@@ -14,8 +14,10 @@ const AllCategories = () => {
 
   const categories = allMarkdownRemark.group.map((category) => category.fieldValue)
   return (
-    <nav className="category-link">
-      <h1 className="title">Categories</h1>
+    <nav className="category-link" aria-labelledby="categories-heading">
+      <h2 id="categories-heading" className="title">
+        Categories
+      </h2>
       <ul>
         {categories.map((category) => {
           return (

--- a/src/components/allTags.jsx
+++ b/src/components/allTags.jsx
@@ -20,8 +20,10 @@ const AllTags = () => {
   })
 
   return (
-    <nav className="tag-link">
-      <h1 className="title">Tags</h1>
+    <nav className="tag-link" aria-labelledby="tags-heading">
+      <h2 id="tags-heading" className="title">
+        Tags
+      </h2>
       <ul>
         {tags.map((tag) => {
           if (tag.fieldValue == '') {

--- a/src/components/layout.jsx
+++ b/src/components/layout.jsx
@@ -15,10 +15,10 @@ const Pagenate = ({ previousPath, nextPath }) => {
   if (previousPath) {
     previousComponent = (
       <div className="previous">
-        <Link to={`${previousPath}`}>
-          <img src={previousPenguin} alt="Previous" className="light-mode" />
-          <img src={previousPenguinWhite} alt="Previous" className="dark-mode" />
-          <p>←Previous</p>
+        <Link to={`${previousPath}`} aria-label="前のページへ">
+          <img src={previousPenguin} alt="" className="light-mode" aria-hidden="true" />
+          <img src={previousPenguinWhite} alt="" className="dark-mode" aria-hidden="true" />
+          <span>←Previous</span>
         </Link>
       </div>
     )
@@ -28,10 +28,10 @@ const Pagenate = ({ previousPath, nextPath }) => {
   if (nextPath) {
     nextComponent = (
       <div className="next">
-        <Link to={`${nextPath}`}>
-          <img src={nextPenguin} alt="Next" className="light-mode" />
-          <img src={nextPenguinWhite} alt="Next" className="dark-mode" />
-          <p>Next→</p>
+        <Link to={`${nextPath}`} aria-label="次のページへ">
+          <img src={nextPenguin} alt="" className="light-mode" aria-hidden="true" />
+          <img src={nextPenguinWhite} alt="" className="dark-mode" aria-hidden="true" />
+          <span>Next→</span>
         </Link>
       </div>
     )
@@ -40,10 +40,10 @@ const Pagenate = ({ previousPath, nextPath }) => {
   }
 
   return (
-    <div className="pagenate">
+    <nav className="pagenate" aria-label="Pagination">
       {previousComponent}
       {nextComponent}
-    </div>
+    </nav>
   )
 }
 

--- a/src/components/penguin.jsx
+++ b/src/components/penguin.jsx
@@ -32,9 +32,9 @@ class Penguin extends React.Component {
     }
     return (
       <div className="date">
-        <img src={src} className="penguin-shadow" />
+        <img src={src} className="penguin-shadow" alt="" aria-hidden="true" />
         <p>
-          <time detatime={this.props.date}>{this.props.date}</time>
+          <time dateTime={this.props.date}>{this.props.date}</time>
         </p>
       </div>
     )

--- a/src/components/posttitle.jsx
+++ b/src/components/posttitle.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 class PostTitle extends React.Component {
   render() {
+    const HeadingTag = this.props.level || 'h1'
     let color
     switch (this.props.category) {
       case '舞台技術':
@@ -26,14 +27,14 @@ class PostTitle extends React.Component {
     }
     return (
       <div className="title-flame">
-        <h1
+        <HeadingTag
           className="title"
           style={{
             borderBottom: `solid ${color} 0.3rem`,
           }}
         >
           {this.props.children}
-        </h1>
+        </HeadingTag>
       </div>
     )
   }

--- a/src/components/readmore.jsx
+++ b/src/components/readmore.jsx
@@ -4,35 +4,14 @@ import { Link } from 'gatsby'
 import './readmore.scss'
 
 const ReadMore = props => {
-  let color = ''
-  switch (props.category) {
-    case '舞台技術':
-      color = '#7CB3D9'
-      break
-
-    case '日記':
-      color = '#00bb16'
-      break
-
-    case '電子工作':
-      color = '#F18AF2'
-      break
-
-    case 'プログラミング':
-      color = '#F29333'
-      break
-
-    default:
-      color = '#b0cc05'
-      break
-  }
   return (
     <Link
       to={props.slug}
       style={{ textDecoration: 'none' }}
       className="readmore-link"
+      aria-label={`「${props.title}」を読む`}
     >
-      <div className={`readmore ${props.category}`}>続きを読む</div>
+      <span className={`readmore ${props.category}`}>続きを読む</span>
     </Link>
   )
 }

--- a/src/components/readmore.scss
+++ b/src/components/readmore.scss
@@ -6,6 +6,7 @@
 
 
 .readmore {
+  display: inline-block;
   margin: auto;
   width: fit-content;
   margin-top: 0.8em;

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,10 +1,14 @@
 import React from 'react'
+import { Link } from 'gatsby'
 
 const NotFoundPage = () => (
-  <div>
+  <main>
     <h1>NOT FOUND</h1>
     <p>You just hit a route that doesn&#39;t exist... the sadness.</p>
-  </div>
+    <p>
+      <Link to="/">トップページに戻る</Link>
+    </p>
+  </main>
 )
 
 export default NotFoundPage

--- a/src/templates/index.jsx
+++ b/src/templates/index.jsx
@@ -47,7 +47,9 @@ const BlogIndex = ({ data, location, pageContext }) => {
             <div className={'content-header'}>
               <div className={'title'}>
                 <Link to={node.fields.slug}>
-                  <PostTitle category={node.frontmatter.category}>{node.frontmatter.title}</PostTitle>
+                  <PostTitle category={node.frontmatter.category} level="h2">
+                    {node.frontmatter.title}
+                  </PostTitle>
                 </Link>
               </div>
               <Penguin category={node.frontmatter.category} date={node.frontmatter.date} />
@@ -55,7 +57,11 @@ const BlogIndex = ({ data, location, pageContext }) => {
             <div className={'content-body'}>
               <p className={'excerpt'} dangerouslySetInnerHTML={{ __html: node.excerpt }} />
             </div>
-            <ReadMore category={node.frontmatter.category} slug={node.fields.slug} />
+            <ReadMore
+              category={node.frontmatter.category}
+              slug={node.fields.slug}
+              title={node.frontmatter.title}
+            />
             <Tags list={node.frontmatter.tags || []} category={node.frontmatter.category || []} />
           </article>
         )

--- a/src/templates/style.scss
+++ b/src/templates/style.scss
@@ -118,9 +118,9 @@ body {
         border-bottom: dashed 1px rgba(255, 255, 255, 0.5);
       }
       a {
-        color: #00b4ff;
+        color: #005a9c;
         &:visited {
-          color: #1d9db3;
+          color: #5a2ca0;
         }
       }
 
@@ -164,7 +164,7 @@ body {
           color: white;
         }
       }
-      h1.title {
+      .title-flame > .title {
         font: {
           font-family: $font-gothic;
           weight: inherit;
@@ -241,9 +241,9 @@ body {
           line-height: 1.8rem;
           margin-bottom: 2rem;
           a {
-            color: #00b4ff;
+            color: #005a9c;
             &:visited {
-              color: #1d9db3;
+              color: #5a2ca0;
             }
           }
         }
@@ -383,7 +383,7 @@ body {
           float: left;
 
           a {
-            color: #00b4ff;
+            color: #005a9c;
             font-family: $font-pop;
           }
 
@@ -414,7 +414,7 @@ body {
     font-family: serif;
 
     box-sizing: border-box;
-    h1 {
+    h2 {
       margin: {
         bottom: 10px;
       }
@@ -491,16 +491,16 @@ body {
     }
 
     a {
-      p {
+      span {
         margin: {
           top: 0px;
           bottom: 0;
         }
         font-family: $font-pop;
       }
-      color: #00b4ff;
+      color: #005a9c;
       &:visited {
-        color: #1d9db3;
+        color: #5a2ca0;
       }
     }
 


### PR DESCRIPTION
## Summary
Improve the blog's baseline accessibility semantics and link usability.

## What Changed
- reduced heading-level misuse on index and shared navigation sections
- marked decorative pagination and penguin images as presentational
- added specific accessible names to read-more links
- fixed the invalid `time` attribute on post dates
- improved 404 recovery with a main landmark and a link back to the homepage
- increased default link contrast in the shared stylesheet

## Why
The site exposed multiple `h1` elements on the same page, duplicated spoken labels in pagination, weakly named repeated links, and low-contrast link colors. Those issues make screen-reader navigation and general readability worse.

## Validation
- `npm run lint`
- `npm run build`
- manual verification with `agent-browser` against the local Gatsby dev server
